### PR TITLE
Add error classes and validation method for permissions

### DIFF
--- a/common/errors/BadRequestError.ts
+++ b/common/errors/BadRequestError.ts
@@ -1,0 +1,6 @@
+export class BadRequestError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}

--- a/common/errors/NotFoundError.ts
+++ b/common/errors/NotFoundError.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/common/errors/UnauthorizedError.ts
+++ b/common/errors/UnauthorizedError.ts
@@ -1,0 +1,6 @@
+export class UnauthorizedError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}

--- a/common/errors/index.ts
+++ b/common/errors/index.ts
@@ -1,0 +1,3 @@
+export * from '@common/errors/BadRequestError';
+export * from '@common/errors/UnauthorizedError';
+export * from '@common/errors/NotFoundError';

--- a/common/services/authorization/AuthorizationServiceBase.ts
+++ b/common/services/authorization/AuthorizationServiceBase.ts
@@ -1,6 +1,7 @@
+import { BadRequestError } from '@common/errors';
 import { PermissionLevel } from '@common/enums/PermissionLevel';
-import { UserType } from '@common/enums/UserType';
 import { PermissionMatrix } from '@common/interfaces/authorization/PermissionMatrix';
+import { UserType } from '@common/enums/UserType';
 
 /**
  * 汎用認可サービス基底クラス
@@ -128,5 +129,17 @@ export abstract class AuthorizationServiceBase<Feature extends string = string> 
   ): Promise<PermissionLevel | null> {
     // デフォルト実装：カスタム権限なし
     return null;
+  }
+
+  /**
+   * 入力の検証
+   * 派生先で override し、Feature の検証も行ってください
+   * @param feature 機能
+   * @param level 権限レベル
+   */
+  public validate(feature: Feature, level: PermissionLevel): void {
+    if (!level || !Object.values(PermissionLevel).includes(level as PermissionLevel)) {
+      throw new BadRequestError('Invalid permission level');
+    }
   }
 }


### PR DESCRIPTION
Introduce `BadRequestError`, `UnauthorizedError`, and `NotFoundError` classes for better error handling. Implement a validation method in `AuthorizationServiceBase` to check permission levels and throw a `BadRequestError` for invalid inputs.