### PR TITLE
v1.10.0

### DIFF
--- a/common/interfaces/data/SubscriptionDataType.ts
+++ b/common/interfaces/data/SubscriptionDataType.ts
@@ -1,0 +1,7 @@
+import { DataTypeBase } from '@common/interfaces/data/DataTypeBase';
+import { SubscriptionType } from '@common/interfaces/SubscriptionType';
+
+export interface SubscriptionDataType extends DataTypeBase {
+  terminalId: string;
+  subscription: SubscriptionType;
+}

--- a/common/interfaces/record/SubscriptionRecordType.ts
+++ b/common/interfaces/record/SubscriptionRecordType.ts
@@ -1,0 +1,8 @@
+import { RecordTypeBase } from '@common/interfaces/record/RecordTypeBase';
+import { SubscriptionType } from '@common/interfaces/SubscriptionType';
+
+export interface SubscriptionRecordType extends RecordTypeBase {
+  DataType: 'Subscription';
+  TerminalID: string;
+  Subscription: SubscriptionType;
+}

--- a/common/services/subscription/SubscriptionDataAccessor.ts
+++ b/common/services/subscription/SubscriptionDataAccessor.ts
@@ -1,0 +1,15 @@
+import DataAccessorBase from '@common/services/DataAccessorBase';
+import DynamoDBService from '@common/services/aws/DynamoDBService';
+import { SubscriptionRecordType } from '@common/interfaces/record/SubscriptionRecordType';
+
+export class SubscriptionDataAccessor extends DataAccessorBase<SubscriptionRecordType> {
+  constructor(dynamoDBService?: DynamoDBService<SubscriptionRecordType>) {
+    const tableName = 'Subscription';
+
+    if (!dynamoDBService) {
+      dynamoDBService = new DynamoDBService<SubscriptionRecordType>(tableName);
+    }
+
+    super(tableName, 'Subscription', dynamoDBService);
+  }
+}

--- a/common/services/subscription/SubscriptionService.ts
+++ b/common/services/subscription/SubscriptionService.ts
@@ -1,0 +1,42 @@
+import CRUDServiceBase from '@common/services/CRUDServiceBase';
+import { SubscriptionDataAccessor } from '@common/services/subscription/SubscriptionDataAccessor';
+import { SubscriptionDataType } from '@common/interfaces/data/SubscriptionDataType';
+import { SubscriptionRecordType } from '@common/interfaces/record/SubscriptionRecordType';
+
+export class SubscriptionService extends CRUDServiceBase<SubscriptionDataType, SubscriptionRecordType> {
+  constructor(dataAccessor?: SubscriptionDataAccessor) {
+    if (!dataAccessor) {
+      dataAccessor = new SubscriptionDataAccessor();
+    }
+
+    super(dataAccessor, true);
+  }
+
+  public async getByTerminalId(terminalId: string): Promise<SubscriptionDataType> {
+    const records = await this.dataAccessor.get();
+    const record = records.find((rec) => rec.TerminalID === terminalId);
+
+    if (!record) {
+      throw new Error(`Subscription record not found for TerminalID: ${terminalId}`);
+    }
+
+    return this.recordToData(record);
+  }
+
+  protected dataToRecord(data: Partial<SubscriptionDataType>): Partial<SubscriptionRecordType> {
+    return {
+      TerminalID: data.terminalId,
+      Subscription: data.subscription,
+    };
+  }
+
+  protected recordToData(record: SubscriptionRecordType): SubscriptionDataType {
+    return {
+      id: record.ID || '',
+      terminalId: record.TerminalID,
+      subscription: record.Subscription,
+      create: record.Create || 0,
+      update: record.Update || 0,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new subscription management feature to the codebase, including new data interfaces and service classes for handling subscription records and data. The changes establish a clear separation between data types, record types, and service layers, providing a foundation for CRUD operations related to subscriptions.

**New subscription data and record interfaces:**

* Added `SubscriptionDataType` interface to define the structure for subscription data, including `terminalId` and `subscription` fields.
* Added `SubscriptionRecordType` interface to represent subscription records in the database, including `TerminalID` and `Subscription` fields.

**Service layer for subscription management:**

* Implemented `SubscriptionDataAccessor` class to handle database interactions for subscription records, utilizing DynamoDB.
* Added `SubscriptionService` class to provide CRUD operations and conversion methods between data and record types, including a `getByTerminalId` method for fetching subscriptions by terminal ID.