### PR TITLE
v1.11.1

### DIFF
--- a/common/consts/OpenAIConst.ts
+++ b/common/consts/OpenAIConst.ts
@@ -1,4 +1,4 @@
-import { ChatCompletionTool } from 'openai/resources/chat';
+import { ChatCompletionTool } from 'openai/resources';
 
 /**
  * OpenAI message roles constants

--- a/common/services/OpenAIService.ts
+++ b/common/services/OpenAIService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat';
+import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources';
 
 import { BadRequestError } from '@common/errors';
 import { OpenAIChatHistory, OpenAIChatOptions } from '@common/interfaces/OpenAIMessageType';


### PR DESCRIPTION
This pull request updates how OpenAI types are imported, making the imports more consistent and future-proof. Specifically, it changes the import paths for `ChatCompletionTool` and `ChatCompletionCreateParamsNonStreaming` to use the main `openai/resources` entry point instead of the submodule.

OpenAI type import improvements:

* Updated the import path for `ChatCompletionTool` in `common/consts/OpenAIConst.ts` to use `openai/resources` instead of `openai/resources/chat`.
* Updated the import path for `ChatCompletionCreateParamsNonStreaming` in `common/services/OpenAIService.ts` to use `openai/resources` instead of `openai/resources/chat`.